### PR TITLE
Add a real-world allocation test case

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,5 @@ static ALLOCATOR: emballoc::Allocator<4096> = emballoc::Allocator::new();
 extern crate alloc;
 ```
 
-Now the crate can use the `std` collections such as `Vec<T>`, `HashMap<K, V>`, etc. together with important types like `Box<T>` and `Rc<T>`.
+Now the crate can use the `std` collections such as `Vec<T>`, `BTreeMap<K, V>`, etc. together with important types like `Box<T>` and `Rc<T>`.
 Note, that things in the `std`-prelude (e.g. `Vec<T>`, `Box<T>`, ...) have to be imported explicitly.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! The usage is simple: just copy and paste the following code snipped into
 //! your binary crate and potentially adjust the number of bytes of the heap
 //! (here 4K):
-//! ```no_run
+//! ```
 //! #[global_allocator]
 //! static ALLOCATOR: emballoc::Allocator<4096> = emballoc::Allocator::new();
 //!
@@ -20,7 +20,7 @@
 //! ```
 //! Afterwards you don't need to interact with the crate or the variable
 //! `ALLOCATOR` anymore. Now you can just `use alloc::vec::Vec` or even
-//! `use alloc::collections::HashMap`, i.e. every fancy collection which is
+//! `use alloc::collections::BTreeMap`, i.e. every fancy collection which is
 //! normally provided by the `std`.
 //!
 //! The minimal buffer size is `8`, which would allow exactly one allocation of

--- a/tests/allocation.rs
+++ b/tests/allocation.rs
@@ -1,0 +1,32 @@
+#![no_std]
+
+const HEAP_SIZE: usize = 4 * 1024 * 1024;
+
+#[global_allocator]
+static ALLOCATOR: emballoc::Allocator<HEAP_SIZE> = emballoc::Allocator::new();
+
+extern crate alloc;
+
+#[test]
+fn vec() {
+    let mut v = alloc::vec![1, 2, 3];
+    v.push(4);
+
+    assert_eq!((1..=4).collect::<alloc::vec::Vec<_>>(), v);
+}
+
+#[test]
+fn map_and_formatting() {
+    let mut map = alloc::collections::BTreeMap::new();
+    map.insert(10, "Hello");
+    map.insert(11, "world");
+    map.insert(20, "Hallo");
+    map.insert(21, "Welt");
+    map.insert(-1, "english");
+    map.insert(-2, "german");
+
+    let english = alloc::format!("[{}]: {}, {}!", map[&-1], map[&10], map[&11]);
+    let german = alloc::format!("[{}]: {}, {}!", map[&-2], map[&20], map[&21]);
+    assert_eq!(english, "[english]: Hello, world!");
+    assert_eq!(german, "[german]: Hallo, Welt!");
+}


### PR DESCRIPTION
This commit adds a simple but important test case: it uses the allocator
on the machine running the tests. Since this is a hosted environment,
allocations are rather frequent and the heap space is relatively large
(here 4M). This way all the allocations in the `std` and in the test
runner are also directed to `emballoc`, which is great for testing.

This commit also contains a minor adjustment: the README and crate-level
documentation previously mentioned the availability of `HashMap`: this
is not true (most likely since `alloc` still has no random generator re-
quired for the random state of the HashMap) and thus replaced with the
`BTreeMap`.