### PR TITLE
Do coverage testing in CI and report to codecov.io

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -2,11 +2,24 @@
 
 This directory contains all the necessary files for th Continuous Integration setup.
 Most importantly, there is the [config.yml](config.yml)-file, which contains the core definitions of the CI.
-It also contains a docker file for a custom container called `jfrimmel/miri`.
+It also contains docker files for custom containers used during the CI run.
+
+## Container for Miri
+
 This container is a version of `rust`, which already contains a pre-setup `miri` environment.
 
 To build the docker container, select the desired nightly version (which, of course, has to contain the `miri` component) and run the following command from the repository root (replace `2022-08-22` with the required version):
 
 ```bash
 docker build -t jfrimmel/miri:nightly-2022-08-22 --build-arg nightly_version=2022-08-22 -f .circleci/miri.Dockerfile .circleci/
+```
+
+## Container for coverage testing
+
+This container is a version of `rust`, which already contains a pre-installed coverage-testing tools.
+
+To build the container use:
+
+```bash
+docker build -t jfrimmel/coverage -f .circleci/coverage.Dockerfile .circleci/
 ```

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  codecov: codecov/codecov@3.2.3
+
 jobs:
   build:
     docker:
@@ -30,6 +33,34 @@ jobs:
       - run:
           name: Run the tests
           command: MIRIFLAGS='-Zmiri-symbolic-alignment-check' cargo miri test --target << parameters.target >> --lib
+
+  coverage:
+    docker:
+      - image: jfrimmel/coverage
+    steps:
+      - checkout
+      - run:
+          name: Record testing coverage
+          command: |
+            env \
+              RUSTFLAGS="-C instrument-coverage" \
+              LLVM_PROFILE_FILE="json5format-%m.profraw" \
+              cargo test
+            llvm-profdata merge -sparse json5format-*.profraw -o json5format.profdata
+            # according to https://doc.rust-lang.org/rustc/instrument-coverage.html#tips-for-listing-the-binaries-automatically
+            llvm-cov report $( \
+                for file in $( \
+                    RUSTFLAGS="-C instrument-coverage" \
+                      cargo test --tests --no-run --message-format=json \
+                        | jq -r "select(.profile.test == true) | .filenames[]" \
+                        | grep -v dSYM - \
+                  ); \
+                do printf "%s %s " -object $file; done \
+              ) \
+              --use-color --ignore-filename-regex='/usr/local/cargo/registry' \
+              --instr-profile=json5format.profdata
+      - codecov/upload:
+          file: json5format.profdata
 
   msrv:
     docker:
@@ -90,6 +121,8 @@ workflows:
             parameters:
               target:
                 ["x86_64-unknown-linux-gnu", "mips64-unknown-linux-gnuabi64"]
+      - coverage:
+          requires: [build]
       - msrv
       - style
       - doc

--- a/.circleci/coverage.Dockerfile
+++ b/.circleci/coverage.Dockerfile
@@ -1,0 +1,7 @@
+FROM rust:1.62.1
+
+RUN rustup component add llvm-tools-preview
+ENV PATH=/usr/local/rustup/toolchains/1.62.1-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin/:$PATH
+RUN apt-get update && \
+    apt-get install -y jq && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This commit adds a new job to the CI: it uses the Rust "instrumented
coverage"-feature to generate accurate coverage reports. The job will
upload the measurement to codecov.io automatically.
It uses a new docker container with pre-installed tooling. It follows
the current recommendations of the rustc book.