### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Embedded memory allocator
 
+[![crates.io](https://img.shields.io/crates/v/emballoc)](https://crates.io/crate/emballoc)
+[![circleci](https://img.shields.io/circleci/build/github/jfrimmel/emballoc)](https://app.circleci.com/pipelines/github/jfrimmel/emballoc)
+[![codecov](https://codecov.io/gh/jfrimmel/emballoc/branch/main/graph/badge.svg?token=XU4EG0HGRP)](https://codecov.io/gh/jfrimmel/emballoc)
+[![docs.rs](https://img.shields.io/docsrs/emballoc)](https://docs.rs/emballoc)
+
 This repository provides the [`emballoc`](https://crates.io/crates/emballoc) crate: a simple memory allocator developed for usage in small embedded systems.
 It is one possible way to support dynamic memory on targets without the standard library, i.e. ones with `#![no_std]`.
 This is achieved by providing a type [`Allocation`](https://docs.rs/emballoc/*/emballoc/struct.Allocator.html) which can be registered as the global allocator for the binary.
@@ -7,7 +12,7 @@ See the usage description below.
 
 An allocator is a rather critical part of a software project:
 when using dynamic memory many operations implicitly can or will allocate, sometimes unexpectedly.
-Therefore a misbehaving allocator can "randomly" crash the program in ver obscure ways.
+Therefore a misbehaving allocator can "randomly" crash the program in very obscure ways.
 As such an allocator has to be well-tested and battle-proven (see more information [here][docu-testing] and a [real world example][gist_hosted-test]).
 Furthermore it has to be _simple_: the simpler the algorithm is, the more likely is a correct implementation.
 
@@ -47,6 +52,8 @@ This sections answers the question:
 - crate is free of undefined behavior according to `miri`
 - it is used in real-world applications
 - it even works on a PC (see [here][gist_hosted-test]), although that is not the primary use case
+- supports the stable compiler as there are only stable features used
+- has only a single dependency on the popular `spin`-crate (without any transitive dependencies)
 
 I'm glad, if that convinced you, but if you have any questions simply [open an issue](https://github.com/jfrimmel/emballoc/issues/new/choose).
 
@@ -59,6 +66,12 @@ A note to users on systems with advanced memory features like MMUs and MPUs:
 - if you have an (active) _memory management unit_ (MMU), this is likely not the crate for you: it doesn't use any of the important features, which makes it perform much worse than possible.
   Use a proper memory allocator for that use case (one that supports paging, etc.).
   However, if you need dynamic memory before enabling the MMU, this crate certainly is an option.
+
+# Minimum supported Rust version
+
+This crate has a stability guarantee about the compiler version supported.
+The so-called minimum supported Rust version is currently set to **1.62** and won't be raised without a proper increase in the semantic version number scheme.
+This MSRV is specified in `Cargo.toml` and is tested in CI.
 
 [docu-testing]: https://docs.rs/emballoc/latest/emballoc/#testing
 [gist_hosted-test]: https://gist.github.com/jfrimmel/61943f9879adfbe760a78efa17a0ecaa


### PR DESCRIPTION
This commit adds the usual badges to the readme, so that the user has
a quick overview of the crate. It also extends the readme with informa-
tion about the MSRV and dependencies. This should make it easier to con-
vince a potential user to actually use this crate.