### PR TITLE
Mention licensing in README

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -173,16 +173,4 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
     incurred by, or claims asserted against, such Contributor by reason
     of your accepting any such warranty or additional liability.
 
-Copyright 2022 J. Frimmel
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+END OF TERMS AND CONDITIONS

--- a/README.md
+++ b/README.md
@@ -73,5 +73,14 @@ This crate has a stability guarantee about the compiler version supported.
 The so-called minimum supported Rust version is currently set to **1.62** and won't be raised without a proper increase in the semantic version number scheme.
 This MSRV is specified in `Cargo.toml` and is tested in CI.
 
+# License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0))
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT))
+
+at your option.
+
 [docu-testing]: https://docs.rs/emballoc/latest/emballoc/#testing
 [gist_hosted-test]: https://gist.github.com/jfrimmel/61943f9879adfbe760a78efa17a0ecaa


### PR DESCRIPTION
This should make the licensing information better accessible. It also
tries to "fix" the Apache license file (GitHub displays "unknown").