### PR TITLE
Test the code snippets of the Readme as doctests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,6 +305,20 @@ unsafe impl<const N: usize> GlobalAlloc for Allocator<N> {
     }
 }
 
+// include the readme in doc-tests. Credits to https://blog.guillaume-gomez.fr/articles/2020-03-07+cfg%28doctest%29+is+stable+and+you+should+use+it
+#[cfg(doctest)]
+mod extra_doctests {
+    /// Helper macro to pass a "dynamic"/included string to the `extern`-block
+    macro_rules! doc_check {
+        ($x:expr) => {
+            #[doc = $x]
+            extern "C" {}
+        };
+    }
+    // Check the code snippets in the Readme.
+    doc_check!(include_str!("../README.md"));
+}
+
 #[cfg(test)]
 mod tests {
     use crate::Allocator;


### PR DESCRIPTION
The Readme features the first code snippet a potential user might see of this crate. Therefore it is highly important, that the code snippet actually compiles and works. This was not ensured by testing, though!

This commit uses a [trick show be G. Gomez][trick] to include the Readme as documentation of an `extern`-block, that is only compiled for doctests. This will ensure, that the Readme will continue to provide working code examples.

[trick]: https://blog.guillaume-gomez.fr/articles/2020-03-07+cfg%28doctest%29+is+stable+and+you+should+use+it