### PR TITLE
Lower the MSRV from `1.62` to `1.57`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
 
   msrv:
     docker:
-      - image: rust:1.62
+      - image: rust:1.57
     steps:
       - checkout
       - run:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["allocator", "embedded", "no-std", "no_std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/jfrimmel/emballoc"
 documentation = "https://docs.rs/emballoc"
-rust-version = "1.62"
+rust-version = "1.57"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ A note to users on systems with advanced memory features like MMUs and MPUs:
 # Minimum supported Rust version
 
 This crate has a stability guarantee about the compiler version supported.
-The so-called minimum supported Rust version is currently set to **1.62** and won't be raised without a proper increase in the semantic version number scheme.
+The so-called minimum supported Rust version is currently set to **1.57** and won't be raised without a proper increase in the semantic version number scheme.
 This MSRV is specified in `Cargo.toml` and is tested in CI.
 
 # License


### PR DESCRIPTION
The newest used feature is using `assert!()` in `const fn`, which was
stabilized in Rust 1.57. Therefore that should be the MSRV. Lowering the
MSRV is allowed, as this cannot break a build, but only allows more
users to depend on the crate.