### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ rust-version = "1.57"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies.spin]
-version = "0.9.4"
+version = "0.9.8"
 default-features = false
 features = ["mutex", "spin_mutex"]


### PR DESCRIPTION
Updates dependency to the patch version of 0.9.8

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0031.html)