### PR TITLE
Speed up some slow build jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,9 +66,15 @@ jobs:
       - image: rust:1.57
     steps:
       - checkout
+      - restore_cache:
+          key: cargo-registry
       - run:
           name: Build the source
           command: cargo check
+      - save_cache:
+          key: cargo-registry
+          paths:
+            - /usr/local/cargo/registry/
 
   style:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       target:
         type: string
     docker:
-      - image: jfrimmel/miri:nightly-2022-08-22
+      - image: jfrimmel/miri:nightly-2023-11-09
     steps:
       - checkout
       - run:
@@ -36,7 +36,7 @@ jobs:
 
   coverage:
     docker:
-      - image: jfrimmel/coverage
+      - image: jfrimmel/coverage:1.1
     steps:
       - checkout
       - run:

--- a/.circleci/coverage.Dockerfile
+++ b/.circleci/coverage.Dockerfile
@@ -1,7 +1,7 @@
-FROM rust:1.62.1
+FROM rust:1.73.0
 
 RUN rustup component add llvm-tools-preview
-ENV PATH=/usr/local/rustup/toolchains/1.62.1-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin/:$PATH
+ENV PATH=/usr/local/rustup/toolchains/1.73.0-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin/:$PATH
 RUN apt-get update && \
     apt-get install -y jq && \
     rm -rf /var/lib/apt/lists/*

--- a/.circleci/miri.Dockerfile
+++ b/.circleci/miri.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.62
+FROM rust:latest
 
 # the specific nightly version to use
 ARG nightly_version


### PR DESCRIPTION
This PR updates the docker images to newer Rust versions. Those new versions support the sparse-registry-feature, which drastically speeds up the altered jobs:

| Job | [old] | [new] |
|------|--------|----------|
| coverage | 4m 59s | 7s |
| miri-mips64 | 5m 09s | 8s |
| miri-x86_64 | 5m 16s | 17s |
| msrv | 4m 53 | 21s |

This is an 90% improvement of the build time.

[old]: https://app.circleci.com/pipelines/github/jfrimmel/emballoc/47/workflows/06759f7f-e30b-46f9-a4f3-fe4d8e65872b
[new]: https://app.circleci.com/pipelines/github/jfrimmel/emballoc/65/workflows/568ed7be-04dc-426c-a205-cc518830ea92