### PR TITLE
Don't place the heap in the `.data`-segment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,6 +285,7 @@ impl<const N: usize> Allocator<N> {
     /// emballoc::Allocator::<4>::new(); // less than 8
     /// ```
     #[must_use = "assign the allocator to a static variable and apply the `#[global_allocator]`-attribute to make it the global allocator"]
+    #[allow(clippy::new_without_default)] // this could be added, but not now
     pub const fn new() -> Self {
         let raw = spin::Mutex::new(RawAllocator::new());
         Self { raw }

--- a/src/raw_allocator/buffer.rs
+++ b/src/raw_allocator/buffer.rs
@@ -172,6 +172,7 @@ impl<const N: usize> Buffer<N> {
     /// obtain the entry after it. If there is no entry after it (because the
     /// given one is the last in the buffer) or if the entry following it is a
     /// used one, then `None` is returned.
+    #[allow(clippy::needless_pass_by_ref_mut)] // this is a "mutable" operation
     pub fn following_free_entry(&mut self, offset: ValidatedOffset) -> Option<Entry> {
         let iter_starting_at_offset = EntryIter {
             buffer: self,

--- a/src/raw_allocator/mod.rs
+++ b/src/raw_allocator/mod.rs
@@ -54,6 +54,8 @@ impl<const N: usize> RawAllocator<N> {
     ///
     /// If the allocation fails, `None` will be returned.
     pub fn alloc(&mut self, n: usize) -> Option<&mut [MaybeUninit<u8>]> {
+        self.buffer.ensure_initialization();
+
         // round up `n` to next multiple of `size_of::<Entry>()`
         let n = (n + HEADER_SIZE - 1) / HEADER_SIZE * HEADER_SIZE;
 
@@ -91,6 +93,8 @@ impl<const N: usize> RawAllocator<N> {
     /// the just freed up one is also free, the two blocks are concatenated to a
     /// single one (to prevent fragmentation).
     pub fn free(&mut self, ptr: *mut u8) -> Result<(), FreeError> {
+        self.buffer.ensure_initialization();
+
         // find the offset of the entry, which the `ptr` points into
         let offset = self
             .buffer

--- a/tests/sections.rs
+++ b/tests/sections.rs
@@ -1,0 +1,72 @@
+//! This test ensures, that the allocator heap is not placed in `.data`.
+//!
+//! The `.data`-section typically contains the non-zero-initialized global
+//! variables, so your `static X: u32 = 42` will show up there. Crucially, this
+//! is also the home of partly-initialized memory (i.e. if not all bytes are
+//! zeroed). This, however, needs not just the actually used RAM but also flash
+//! (on the most micro-controllers and embedded devices): the initialization
+//! data for the variables in `.data` (hence the name). So: every variable in
+//! `.data` also shows up in the non-volatile flash. This is fine and expected.
+//!
+//! The aforementioned behavior is bad for the allocator: if the allocator is
+//! located in the `.data`-section, the whole initial heap is also stored in the
+//! non-volatile flash, despite the fact, that _all but the first four bytes are
+//! uninitialized_!
+//!
+//! Therefore this test makes sure, that an global allocator is not placed in
+//! the `.data`-section. This ensures, that issues like [#30] won't pop up
+//! again.
+//!
+//! [#30]: https://github.com/jfrimmel/emballoc/issues/30
+
+use std::alloc::{GlobalAlloc, Layout};
+use std::ptr;
+
+static ALLOCATOR: emballoc::Allocator<{ 128 * 1024 * 1024 }> = emballoc::Allocator::new();
+
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))] // this is only tested on Linux
+#[test]
+fn ensure_that_allocator_memory_is_not_initialized() {
+    // Just use the allocator in order to make sure that it will actually remain
+    // in the binary.
+    // SAFETY: we just use the allocator as intended.
+    unsafe {
+        let layout = Layout::new::<u64>();
+        let ptr = ALLOCATOR.alloc(layout);
+        ALLOCATOR.dealloc(ptr, layout);
+    }
+
+    let memory_map = MemoryMap::new();
+    assert_eq!(
+        memory_map.bss_start, memory_map.data_end,
+        "test assumes .bss directly after .data"
+    );
+
+    let addr_allocator = ptr::addr_of!(ALLOCATOR) as usize;
+    assert!(
+        addr_allocator >= memory_map.bss_start,
+        "The allocator is placed in the .data-segment"
+    );
+}
+
+/// The (at runtime) reconstructed memory map containing addresses of sections.
+struct MemoryMap {
+    /// The end of the `.data`-section.
+    data_end: usize,
+    /// The start address of the `.bss`-section.
+    bss_start: usize,
+}
+impl MemoryMap {
+    pub fn new() -> Self {
+        // The symbols defined in the (default) linker script
+        extern "C" {
+            static __bss_start: usize;
+            static _edata: usize;
+        }
+
+        Self {
+            data_end: unsafe { ptr::addr_of!(__bss_start) } as usize,
+            bss_start: unsafe { ptr::addr_of!(_edata) } as usize,
+        }
+    }
+}

--- a/tests/sections.rs
+++ b/tests/sections.rs
@@ -37,16 +37,12 @@ fn ensure_that_allocator_memory_is_not_initialized() {
     }
 
     let memory_map = MemoryMap::new();
-    assert_eq!(
-        memory_map.bss_start, memory_map.data_end,
-        "test assumes .bss directly after .data"
-    );
+    let bss_start = memory_map.bss_start;
+    let data_end = memory_map.data_end;
+    assert_eq!(bss_start, data_end, "test assumes bss directly after data");
 
     let addr_allocator = ptr::addr_of!(ALLOCATOR) as usize;
-    assert!(
-        addr_allocator >= memory_map.bss_start,
-        "The allocator is placed in the .data-segment"
-    );
+    assert!(addr_allocator >= bss_start, "allocator is placed in .data");
 }
 
 /// The (at runtime) reconstructed memory map containing addresses of sections.


### PR DESCRIPTION
As reported in #30, all versions of ` emballoc` up to and including the current release `v0.2.0` place the `Allocator` and hence its buffer in the `.data`-segment. This is bad, because this needs to initialize memory, that is almost entirely uninitialized. This extra work would not be bad, if it wasn't for a copy of the data in the the non-volatile memory! This bloats up the flash size with the size of the heap. This is especially bad for small microcontrollers.

This PR changes the allocator internally to be lazily-initialized, which causes the memory to be entirely uninitialized and therefore typically placed inside the `.bss`-section. Note, that the memory therefore will typically still initialized, but this time with zero and hence without the need for a heap initialization blob.

**cc** @stephan-gh: you might want to test this :wink: 

The implementation is rather simple. The old internal buffer type `[MaybeUninit<u8>; N]` is now wrapped into a new type `LazyInitializedBuffer`, which also stores, whether or not the buffer was already initialized. If it was not, it gets initialized in the de-reference operator. Implementing this operator makes the new type behave like the old type in this use case. The initialization doesn't need to run in the `DerefMut`-case, since in _this codebase_, a non-mutable call always precedes a mutable one.

Note, that using a `Once` is not possible for two reasons:
1. it is not yet present in the `std`-version 1.57, which is the MSRV
2. the type would then also end up in `.data`, as the `Once` holds an `Option` containing the callback.

Therefore we'll stick to the "simple" implementation, which has the downside, that the `LazyInitializedBuffer` needs to know, how to initialize the buffer (i.e. the initialization-code is not local to the `Buffer`-type.